### PR TITLE
Add firstDayOfWeek feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See the [Basic Usage](#basic-usage) section to see how you can build a basic cal
   * [Props](#props)
     * [#startCurrentDateAt](#startcurrentdateat)
     * [#defaultFormat](#defaultformat)
+    * [#firstDayOfWeek](#firstdayofweek)
     * [#onChange](#onchange)
     * [#onDateChange](#ondatechange)
     * [#onSelectedChange](#onselectedchange)
@@ -193,6 +194,19 @@ Modifies the default format value on the [`#getFormattedDate`](#getformatteddate
 const myFormat = 'yyyy-mm-dd'
 
 <Kalendaryo defaultFormat={myFormat} />
+```
+
+#### #firstDayOfWeek
+<pre>
+<b>type:</b> Number
+<b>required:</b> false
+<b>default</b> 0
+</pre>
+
+The index of the first day of the week (0 - Sunday)
+
+```js
+<Kalendaryo firstDayOfWeek={1} />
 ```
 
 #### #onChange

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [Basic Usage](#basic-usage) section to see how you can build a basic cal
   * [Props](#props)
     * [#startCurrentDateAt](#startcurrentdateat)
     * [#defaultFormat](#defaultformat)
-    * [#firstDayOfWeek](#firstdayofweek)
+    * [#startWeekAt](#firstdayofweek)
     * [#onChange](#onchange)
     * [#onDateChange](#ondatechange)
     * [#onSelectedChange](#onselectedchange)
@@ -185,7 +185,7 @@ const birthday = new Date(1988, 4, 27)
 <pre>
 <b>type:</b> String
 <b>required:</b> false
-<b>default</b> 'MM/DD/YY'
+<b>default:</b> 'MM/DD/YY'
 </pre>
 
 Modifies the default format value on the [`#getFormattedDate`](#getformatteddate) method. Accepts any format that [date-fns' `format` function](https://date-fns.org/v1.29.0/docs/format) can support.
@@ -196,17 +196,19 @@ const myFormat = 'yyyy-mm-dd'
 <Kalendaryo defaultFormat={myFormat} />
 ```
 
-#### #firstDayOfWeek
+#### #startWeekAt
 <pre>
 <b>type:</b> Number
 <b>required:</b> false
-<b>default</b> 0
+<b>default:</b> 0
 </pre>
 
-The index of the first day of the week (0 - Sunday)
+Modifies the starting day index of the weeks returned from the [`#getWeeksInMonth`](#getweeksinmonth). Defaults to `0 (sunday)`
 
 ```js
-<Kalendaryo firstDayOfWeek={1} />
+const monday = 1
+
+<Kalendaryo startWeekAt={monday} />
 ```
 
 #### #onChange
@@ -466,21 +468,25 @@ function MyCalendar(kalendaryo) {
 
 #### #getWeeksInMonth
 <pre>
-<b>type:</b> func(date?: Date): WeekArray: DayArray: { label: Integer, dateValue: Date }
+<b>type:</b> func(date?: Date | startingDayIndex?: Integer, startingDayIndex?: Integer): WeekArray: DayArray: { label: Integer, dateValue: Date }
 </pre>
 
-Returns an array of each weeks for the month of the given date, each array of weeks contain an array of days for that week. You can invoke this in two ways:
+Returns an array of each weeks for the month of the given date, each array of weeks contain an array of days for that week. You can invoke this in four ways:
 
-  * `getWeeksInMonth()` - When **no argument** is given, by default `#getWeeksInMonth` returns an array of weeks for the month of the [`#date`](#date) state's value
+  * `getWeeksInMonth()` - Returns an array for the weeks in the month of the [`#date`](#date) state with the days starting at the value of [`#startWeekAt`](#startweekat) prop
 
-  * `getWeeksInMonth(date)` - When a **date object** is given, `#getWeeksInMonth` returns an array of weeks for the month of the given date value
+  * `getWeeksInMonth(date)` - Returns an array for the weeks in the month of the given `date` argument, with the days starting at the value of [`#startWeekAt`](#startweekat) prop
+
+  * `getWeeksInMonth(startingDayIndex)` - Returns an array for the weeks in the month of the [`#date`](#date) state, with the days starting at the value of the given `startingDayIndex` argument
+
+  * `getWeeksInMonth(date, startingDayIndex)` - Returns an array for the weeks in the given `date` argument, with the days starting at the value of the `startingDayIndex` argument
 
 **NOTE:** Throws an error if an invalid argument value is passed to the function
 
 ```js
 function MyCalendar(kalendaryo) {
   const prevMonth = kalendaryo.getDateNextMonth()
-  const weeksPrevMonth = kalendaryo.getWeeksInMonth(prevMonth)
+  const weeksPrevMonth = kalendaryo.getWeeksInMonth(prevMonth, 1)
 
   return (
     <div>

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ class Kalendaryo extends Component {
   }
 
   static defaultProps = {
+    firstDayOfWeek: 0,
     startCurrentDateAt: new Date(),
     defaultFormat: 'MM/DD/YY'
   }
@@ -37,6 +38,7 @@ class Kalendaryo extends Component {
     onChange: pt.func,
     onDateChange: pt.func,
     onSelectedChange: pt.func,
+    firstDayOfWeek: pt.number,
     defaultFormat: pt.string,
     startCurrentDateAt: props =>
       !isDate(props.startCurrentDateAt) ? new Error('Value is not an instance of Date') : null
@@ -98,17 +100,19 @@ class Kalendaryo extends Component {
   getWeeksInMonth = (date = this.state.date) => {
     if (!isDate(date)) throw new Error('Value is not an instance of Date')
 
+    const { firstDayOfWeek } = this.props
+    const weekOptions = { weekStartsOn: firstDayOfWeek }
     const firstDayOfMonth = startOfMonth(date)
-    const firstDayOfFirstWeek = startOfWeek(firstDayOfMonth)
-    const lastDayOfFirstWeek = endOfWeek(firstDayOfMonth)
+    const firstDayOfFirstWeek = startOfWeek(firstDayOfMonth, weekOptions)
+    const lastDayOfFirstWeek = endOfWeek(firstDayOfMonth, weekOptions)
 
     const getWeeks = (startDay, endDay, weekArray = []) => {
       const week = eachDay(startDay, endDay).map(dateToDayObjects)
       const weeks = [...weekArray, week]
       const nextWeek = addWeeks(startDay, 1)
 
-      const firstDayNextWeek = startOfWeek(nextWeek)
-      const lastDayNextWeek = endOfWeek(nextWeek)
+      const firstDayNextWeek = startOfWeek(nextWeek, weekOptions)
+      const lastDayNextWeek = endOfWeek(nextWeek, weekOptions)
 
       if (isSameMonth(firstDayNextWeek, date)) {
         return getWeeks(firstDayNextWeek, lastDayNextWeek, weeks)

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ class Kalendaryo extends Component {
   }
 
   static defaultProps = {
-    firstDayOfWeek: 0,
+    startWeekAt: 0,
     startCurrentDateAt: new Date(),
     defaultFormat: 'MM/DD/YY'
   }
@@ -38,7 +38,7 @@ class Kalendaryo extends Component {
     onChange: pt.func,
     onDateChange: pt.func,
     onSelectedChange: pt.func,
-    firstDayOfWeek: pt.number,
+    startWeekAt: pt.number,
     defaultFormat: pt.string,
     startCurrentDateAt: props =>
       !isDate(props.startCurrentDateAt) ? new Error('Value is not an instance of Date') : null
@@ -97,12 +97,17 @@ class Kalendaryo extends Component {
     return eachDay(startOfMonth(date), endOfMonth(date)).map(dateToDayObjects)
   }
 
-  getWeeksInMonth = (date = this.state.date) => {
-    if (!isDate(date)) throw new Error('Value is not an instance of Date')
+  getWeeksInMonth = (arg = this.state.date, weekStartsOn = this.props.startWeekAt) => {
+    if (!isDate(arg) && !Number.isInteger(arg)) {
+      throw new Error(`First argument must be a date or an integer`)
+    }
 
-    const { firstDayOfWeek } = this.props
-    const weekOptions = { weekStartsOn: firstDayOfWeek }
-    const firstDayOfMonth = startOfMonth(date)
+    if (!Number.isInteger(weekStartsOn)) {
+      throw new Error('Second argument must be an integer')
+    }
+
+    const weekOptions = { weekStartsOn }
+    const firstDayOfMonth = startOfMonth(arg)
     const firstDayOfFirstWeek = startOfWeek(firstDayOfMonth, weekOptions)
     const lastDayOfFirstWeek = endOfWeek(firstDayOfMonth, weekOptions)
 
@@ -114,7 +119,7 @@ class Kalendaryo extends Component {
       const firstDayNextWeek = startOfWeek(nextWeek, weekOptions)
       const lastDayNextWeek = endOfWeek(nextWeek, weekOptions)
 
-      if (isSameMonth(firstDayNextWeek, date)) {
+      if (isSameMonth(firstDayNextWeek, arg)) {
         return getWeeks(firstDayNextWeek, lastDayNextWeek, weeks)
       }
 

--- a/tests/kalendaryo.spec.js
+++ b/tests/kalendaryo.spec.js
@@ -334,6 +334,20 @@ describe('<Kalendaryo />', () => {
         })
       })
 
+      test('returns the correct weeks for the current month of the current date by default with custom firstDayOfWeek', () => {
+        const component = getComponentInstance({ firstDayOfWeek: 1 })
+
+        const firstDayOfMonth = startOfMonth(dateToday)
+        let weekOfMonth = startOfWeek(firstDayOfMonth, { weekStartsOn: 1 })
+
+        component.getWeeksInMonth().forEach(week => {
+          week.forEach((day) => {
+            expect(isSameWeek(day.dateValue, weekOfMonth)).toBe(true)
+          })
+          weekOfMonth = addWeeks(weekOfMonth, 1)
+        })
+      })
+
       test('returns the correct weeks for the date of May 23, 1996', () => {
         const firstDayOfMonth = startOfMonth(birthday)
         let weekOfMonth = startOfWeek(firstDayOfMonth)

--- a/tests/kalendaryo.spec.js
+++ b/tests/kalendaryo.spec.js
@@ -314,15 +314,21 @@ describe('<Kalendaryo />', () => {
     })
 
     describe('#getWeeksInMonth', () => {
-      test('throws an error when given an invalid date value', () => {
+      test('throws an error when the first argument given is neither a `Date` or an `Integer`', () => {
         expect(() => kalendaryo.getWeeksInMonth(false)).toThrow()
+        expect(() => kalendaryo.getWeeksInMonth('string')).toThrow()
+      })
+
+      test('throws an error when the second argument given is not an `Integer`', () => {
+        expect(() => kalendaryo.getWeeksInMonth(birthday, false)).toThrow()
+        expect(() => kalendaryo.getWeeksInMonth(birthday, 'string')).toThrow()
       })
 
       test('returns an Array', () => {
         expect(kalendaryo.getWeeksInMonth()).toBeInstanceOf(Array)
       })
 
-      test('returns the correct weeks for the current month of the current date by default', () => {
+      test('returns the correct weeks for the month of the current date state by default', () => {
         const firstDayOfMonth = startOfMonth(dateToday)
         let weekOfMonth = startOfWeek(firstDayOfMonth)
 
@@ -334,15 +340,15 @@ describe('<Kalendaryo />', () => {
         })
       })
 
-      test('returns the correct weeks for the current month of the current date by default with custom firstDayOfWeek', () => {
-        const component = getComponentInstance({ firstDayOfWeek: 1 })
+      test('starts the weeks to Monday if `startWeekAt` prop is 1', () => {
+        const component = getComponentInstance({ startWeekAt: 1 })
 
         const firstDayOfMonth = startOfMonth(dateToday)
         let weekOfMonth = startOfWeek(firstDayOfMonth, { weekStartsOn: 1 })
 
         component.getWeeksInMonth().forEach(week => {
           week.forEach((day) => {
-            expect(isSameWeek(day.dateValue, weekOfMonth)).toBe(true)
+            expect(isSameWeek(day.dateValue, weekOfMonth, { weekStartsOn: 1 })).toBe(true)
           })
           weekOfMonth = addWeeks(weekOfMonth, 1)
         })


### PR DESCRIPTION
In some locales, weeks start on Monday instead of Sunday.
This adds `firstDayOfWeek` (defaults to 0 - Sunday) to allow users to customise the weeks.