### PR TITLE
Changes for v1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,16 +468,14 @@ function MyCalendar(kalendaryo) {
 
 #### #getWeeksInMonth
 <pre>
-<b>type:</b> func(date?: Date | startingDayIndex?: Integer, startingDayIndex?: Integer): WeekArray: DayArray: { label: Integer, dateValue: Date }
+<b>type:</b> func(date?: Date, startingDayIndex?: Integer): WeekArray: DayArray: { label: Integer, dateValue: Date }
 </pre>
 
-Returns an array of each weeks for the month of the given date, each array of weeks contain an array of days for that week. You can invoke this in four ways:
+Returns an array of each weeks for the month of the given date, each array of weeks contain an array of days for that week. You can invoke this in three ways:
 
   * `getWeeksInMonth()` - Returns an array for the weeks in the month of the [`#date`](#date) state with the days starting at the value of [`#startWeekAt`](#startweekat) prop
 
   * `getWeeksInMonth(date)` - Returns an array for the weeks in the month of the given `date` argument, with the days starting at the value of [`#startWeekAt`](#startweekat) prop
-
-  * `getWeeksInMonth(startingDayIndex)` - Returns an array for the weeks in the month of the [`#date`](#date) state, with the days starting at the value of the given `startingDayIndex` argument
 
   * `getWeeksInMonth(date, startingDayIndex)` - Returns an array for the weeks in the given `date` argument, with the days starting at the value of the `startingDayIndex` argument
 
@@ -485,7 +483,7 @@ Returns an array of each weeks for the month of the given date, each array of we
 
 ```js
 function MyCalendar(kalendaryo) {
-  const prevMonth = kalendaryo.getDateNextMonth()
+  const prevMonth = kalendaryo.getDatePrevMonth()
   const weeksPrevMonth = kalendaryo.getWeeksInMonth(prevMonth, 1)
 
   return (

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See the [Basic Usage](#basic-usage) section to see how you can build a basic cal
     * [#selectedDate](#selecteddate)
   * [Props](#props)
     * [#startCurrentDateAt](#startcurrentdateat)
+    * [#startSelectedDateAt](#startselecteddateat)
     * [#defaultFormat](#defaultformat)
     * [#startWeekAt](#startweekat)
     * [#onChange](#onchange)
@@ -163,7 +164,7 @@ Is the state for the *current date* the component is in. By convention, you shou
 #### #selectedDate
 <pre><b>type:</b> Date</pre>
 
-Is the state for the *selected date* on the component. By convention, you should only change this when the calendar you're building receives a date selection input from the user, *i.e.* selecting a day on the calendar. Defaults to today's date if [startCurrentDateAt](#startcurrentdateat) prop is not set.
+Is the state for the *selected date* on the component. By convention, you should only change this when the calendar you're building receives a date selection input from the user, *i.e.* selecting a day on the calendar. Defaults to today's date if [startSelectedDateAt](#startselecteddateat) prop is not set.
 
 ### Props
 #### #startCurrentDateAt
@@ -173,12 +174,31 @@ Is the state for the *selected date* on the component. By convention, you should
 <b>default:</b> new Date()
 </pre>
 
-Modifies the initial value of [`#date`](#date) & [`#selectedDate`](#selecteddate) states. Great for when you want your calendar to boot up in some date other than today.
+Modifies the initial value of [`#date`](#date). Great for when you want your calendar to boot up in some date other than today.
+
+Passing non-`Date` types to this prop sets the [`#date`](#date) state to today.
 
 ```js
 const birthday = new Date(1988, 4, 27)
 
 <Kalendaryo startCurrentDateAt={birthday} />
+```
+
+#### #startSelectedDateAt
+<pre>
+<b>type:</b> Date
+<b>required:</b> false
+<b>default:</b> new Date()
+</pre>
+
+Modifies the initial value of [`#selectedDate`](#selecteddate). Great for when you want your calendar's selected date to boot up in some other date than today.
+
+Passing non-`Date` types to this prop sets the [`#selectedDate`](#selecteddate) state to today.
+
+```js
+const birthday = new Date(1988, 4, 27)
+
+<Kalendaryo startSelectedDateAt={birthday} />
 ```
 
 #### #defaultFormat

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,16 @@ var dateToDayObjects = function dateToDayObjects(dateValue) {
   };
 };
 
+var getState = function getState(props) {
+  var startCurrentDateAt = props.startCurrentDateAt,
+      startSelectedDateAt = props.startSelectedDateAt;
+
+  return {
+    date: (0, _dateFns.isDate)(startCurrentDateAt) ? startCurrentDateAt : new Date(),
+    selectedDate: (0, _dateFns.isDate)(startSelectedDateAt) ? startSelectedDateAt : new Date()
+  };
+};
+
 var Kalendaryo = function (_Component) {
   _inherits(Kalendaryo, _Component);
 
@@ -49,10 +59,7 @@ var Kalendaryo = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Kalendaryo.__proto__ || Object.getPrototypeOf(Kalendaryo)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
-      date: _this.props.startCurrentDateAt,
-      selectedDate: _this.props.startCurrentDateAt
-    }, _this.getFormattedDate = function () {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Kalendaryo.__proto__ || Object.getPrototypeOf(Kalendaryo)).call.apply(_ref, [this].concat(args))), _this), _this.state = getState(_this.props), _this.getFormattedDate = function () {
       var arg = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.state.date;
       var dateFormat = arguments[1];
 
@@ -109,11 +116,11 @@ var Kalendaryo = function (_Component) {
       if (!(0, _dateFns.isDate)(date)) throw new Error('Value is not an instance of Date');
       return (0, _dateFns.eachDay)((0, _dateFns.startOfMonth)(date), (0, _dateFns.endOfMonth)(date)).map(dateToDayObjects);
     }, _this.getWeeksInMonth = function () {
-      var arg = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.state.date;
+      var date = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.state.date;
       var weekStartsOn = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _this.props.startWeekAt;
 
-      if (!(0, _dateFns.isDate)(arg) && !Number.isInteger(arg)) {
-        throw new Error('First argument must be a date or an integer');
+      if (!(0, _dateFns.isDate)(date)) {
+        throw new Error('First argument must be a date');
       }
 
       if (!Number.isInteger(weekStartsOn)) {
@@ -121,7 +128,7 @@ var Kalendaryo = function (_Component) {
       }
 
       var weekOptions = { weekStartsOn: weekStartsOn };
-      var firstDayOfMonth = (0, _dateFns.startOfMonth)(arg);
+      var firstDayOfMonth = (0, _dateFns.startOfMonth)(date);
       var firstDayOfFirstWeek = (0, _dateFns.startOfWeek)(firstDayOfMonth, weekOptions);
       var lastDayOfFirstWeek = (0, _dateFns.endOfWeek)(firstDayOfMonth, weekOptions);
 
@@ -135,7 +142,7 @@ var Kalendaryo = function (_Component) {
         var firstDayNextWeek = (0, _dateFns.startOfWeek)(nextWeek, weekOptions);
         var lastDayNextWeek = (0, _dateFns.endOfWeek)(nextWeek, weekOptions);
 
-        if ((0, _dateFns.isSameMonth)(firstDayNextWeek, arg)) {
+        if ((0, _dateFns.isSameMonth)(firstDayNextWeek, date)) {
           return getWeeks(firstDayNextWeek, lastDayNextWeek, weeks);
         }
 
@@ -221,6 +228,7 @@ var Kalendaryo = function (_Component) {
 Kalendaryo.defaultProps = {
   startWeekAt: 0,
   startCurrentDateAt: new Date(),
+  startSelectedDateAt: new Date(),
   defaultFormat: 'MM/DD/YY'
 };
 Kalendaryo.propTypes = {
@@ -230,8 +238,6 @@ Kalendaryo.propTypes = {
   onSelectedChange: _propTypes2.default.func,
   startWeekAt: _propTypes2.default.number,
   defaultFormat: _propTypes2.default.string,
-  startCurrentDateAt: function startCurrentDateAt(props) {
-    return !(0, _dateFns.isDate)(props.startCurrentDateAt) ? new Error('Value is not an instance of Date') : null;
-  }
+  startCurrentDateAt: _propTypes2.default.any
 };
 exports.default = Kalendaryo;

--- a/src/index.js
+++ b/src/index.js
@@ -21,15 +21,21 @@ const dateToDayObjects = dateValue => ({
   label: getDate(dateValue)
 })
 
-class Kalendaryo extends Component {
-  state = {
-    date: this.props.startCurrentDateAt,
-    selectedDate: this.props.startCurrentDateAt
+const getState = props => {
+  const {startCurrentDateAt, startSelectedDateAt} = props
+  return {
+    date: isDate(startCurrentDateAt) ? startCurrentDateAt : new Date(),
+    selectedDate: isDate(startSelectedDateAt) ? startSelectedDateAt : new Date()
   }
+}
+
+class Kalendaryo extends Component {
+  state = getState(this.props)
 
   static defaultProps = {
     startWeekAt: 0,
     startCurrentDateAt: new Date(),
+    startSelectedDateAt: new Date(),
     defaultFormat: 'MM/DD/YY'
   }
 
@@ -40,8 +46,7 @@ class Kalendaryo extends Component {
     onSelectedChange: pt.func,
     startWeekAt: pt.number,
     defaultFormat: pt.string,
-    startCurrentDateAt: props =>
-      !isDate(props.startCurrentDateAt) ? new Error('Value is not an instance of Date') : null
+    startCurrentDateAt: pt.any
   }
 
   getFormattedDate = (arg = this.state.date, dateFormat) => {

--- a/src/index.js
+++ b/src/index.js
@@ -97,9 +97,9 @@ class Kalendaryo extends Component {
     return eachDay(startOfMonth(date), endOfMonth(date)).map(dateToDayObjects)
   }
 
-  getWeeksInMonth = (arg = this.state.date, weekStartsOn = this.props.startWeekAt) => {
-    if (!isDate(arg) && !Number.isInteger(arg)) {
-      throw new Error(`First argument must be a date or an integer`)
+  getWeeksInMonth = (date = this.state.date, weekStartsOn = this.props.startWeekAt) => {
+    if (!isDate(date)) {
+      throw new Error(`First argument must be a date`)
     }
 
     if (!Number.isInteger(weekStartsOn)) {
@@ -107,7 +107,7 @@ class Kalendaryo extends Component {
     }
 
     const weekOptions = { weekStartsOn }
-    const firstDayOfMonth = startOfMonth(arg)
+    const firstDayOfMonth = startOfMonth(date)
     const firstDayOfFirstWeek = startOfWeek(firstDayOfMonth, weekOptions)
     const lastDayOfFirstWeek = endOfWeek(firstDayOfMonth, weekOptions)
 
@@ -119,7 +119,7 @@ class Kalendaryo extends Component {
       const firstDayNextWeek = startOfWeek(nextWeek, weekOptions)
       const lastDayNextWeek = endOfWeek(nextWeek, weekOptions)
 
-      if (isSameMonth(firstDayNextWeek, arg)) {
+      if (isSameMonth(firstDayNextWeek, date)) {
         return getWeeks(firstDayNextWeek, lastDayNextWeek, weeks)
       }
 

--- a/tests/kalendaryo.spec.js
+++ b/tests/kalendaryo.spec.js
@@ -314,9 +314,10 @@ describe('<Kalendaryo />', () => {
     })
 
     describe('#getWeeksInMonth', () => {
-      test('throws an error when the first argument given is neither a `Date` or an `Integer`', () => {
+      test('throws an error when the first argument given is not a `Date`', () => {
         expect(() => kalendaryo.getWeeksInMonth(false)).toThrow()
         expect(() => kalendaryo.getWeeksInMonth('string')).toThrow()
+        expect(() => kalendaryo.getWeeksInMonth(1)).toThrow()
       })
 
       test('throws an error when the second argument given is not an `Integer`', () => {

--- a/tests/kalendaryo.spec.js
+++ b/tests/kalendaryo.spec.js
@@ -11,8 +11,16 @@ beforeEach(() => {
 describe('<Kalendaryo />', () => {
   describe('Props', () => {
     describe('#startCurrentDateAt', () => {
-      test("is set to today's date with default format", () => {
+      test('is set to today\'s date by default', () => {
         expect(format(props.startCurrentDateAt, props.defaultFormat)).toEqual(
+          format(dateToday, props.defaultFormat)
+        )
+      })
+
+      test('is set to today\'s date if the given value is any type other than `Date`', () => {
+        const component = getComponentInstance({ startCurrentDateAt: false })
+        const {date} = component.state
+        expect(format(date, props.defaultFormat)).toEqual(
           format(dateToday, props.defaultFormat)
         )
       })
@@ -20,10 +28,25 @@ describe('<Kalendaryo />', () => {
       test('is as a Date object by default', () => {
         expect(props.startCurrentDateAt).toBeInstanceOf(Date)
       })
+    })
 
-      test('prints a console error for non-date type values', () => {
-        getComponentInstance({ startCurrentDateAt: false })
-        expect(console.warn).toThrow()
+    describe('#startSelectedDateAt', () => {
+      test('is set to today\'s date by default', () => {
+        expect(format(props.startSelectedDateAt, props.defaultFormat)).toEqual(
+          format(dateToday, props.defaultFormat)
+        )
+      })
+
+      test('is set to today\'s date if the given value is any type other than `Date`', () => {
+        const component = getComponentInstance({ startSelectedDateAt: false })
+        const {date} = component.state
+        expect(format(date, props.defaultFormat)).toEqual(
+          format(dateToday, props.defaultFormat)
+        )
+      })
+
+      test('is as a Date object by default', () => {
+        expect(props.startSelectedDateAt).toBeInstanceOf(Date)
       })
     })
 
@@ -297,7 +320,7 @@ describe('<Kalendaryo />', () => {
         expect(kalendaryo.getDaysInMonth()).toBeInstanceOf(Array)
       })
 
-      test("has an array length equal to the number of days of today's month when given no arguments", () => {
+      test('has an array length equal to the number of days of today\'s month when given no arguments', () => {
         const totalDaysThisMonth = getDaysInMonth(dateToday)
         expect(kalendaryo.getDaysInMonth()).toHaveLength(totalDaysThisMonth)
       })


### PR DESCRIPTION
**Changelog:**

- [**`#getWeeksInMonth`**](https://github.com/geeofree/kalendaryo/tree/fix#getweeksinmonth) - *Modified*. Should now only accept the first argument with `Date` types only and the second argument with `Integer` types only
- [**`#startCurrentDateAt`**](https://github.com/geeofree/kalendaryo/tree/fix#startcurrentdateat) - *Modified*. Should now only change the [`#date`](https://github.com/geeofree/kalendaryo/tree/fix#date) state when set instead of both `date` and [`#selectedDate`](https://github.com/geeofree/kalendaryo/tree/fix#selectedDate). Also added a feature to set the `date` to today if the given value is a non-`Date` type
- [**`#startSelectedDateAt`**](https://github.com/geeofree/kalendaryo/tree/fix#startselecteddateat) - *New Prop*. Same functionality as `#startCurrentDateAt`, only that it changes the `selectedDate` state