### PR TITLE
Add shortcut methods and a method for getting the labels of days on a week

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# kalendaryo
+# Kalendaryo
 [![Coverage Status][coveralls-badge]][coveralls]
 [![Build Status][travis-badge]][travis]
 [![npm][npm-badge]][npm]
@@ -43,9 +43,12 @@ See the [Basic Usage](#basic-usage) section to see how you can build a basic cal
     * [#getDatePrevMonth](#getdateprevmonth)
     * [#getDaysInMonth](#getdaysinmonth)
     * [#getWeeksInMonth](#getweeksinmonth)
+    * [#getDayLabelsInWeek](#getdaylabelsinweek)
     * [#setDate](#setdate)
     * [#setSelectedDate](#setselecteddate)
     * [#pickDate](#pickdate)
+    * [#setDateNextMonth](#setdatenextmonth)
+    * [#setDatePrevMonth](#setdateprevmonth)
 * [Examples](#examples)
 * [Inspiration](#inspiration)
 
@@ -70,17 +73,15 @@ function MyCalendar(kalendaryo) {
   const {
     getFormattedDate,
     getWeeksInMonth,
-    getDatePrevMonth,
-    getDateNextMonth,
-    setSelectedDate,
-    setDate
+    getDayLabelsInWeek,
+    setDatePrevMonth,
+    setDateNextMonth,
+    setSelectedDate
   } = kalendaryo
 
   const currentDate = getFormattedDate("MMMM YYYY")
   const weeksInCurrentMonth = getWeeksInMonth()
-
-  const setDateNextMonth = () => setDate(getDateNextMonth())
-  const setDatePrevMonth = () => setDate(getDatePrevMonth())
+  const dayLabels = getDayLabelsInWeek()
   const selectDay = date => () => setSelectedDate(date)
 
   /* For this basic example we're going to build a calendar that has:
@@ -110,13 +111,9 @@ function MyCalendar(kalendaryo) {
       <div className="my-calendar-body">
         // (2.1)
         <div className="week day-labels">
-          <div className="day">Sun</div>
-          <div className="day">Mon</div>
-          <div className="day">Tue</div>
-          <div className="day">Wed</div>
-          <div className="day">Thu</div>
-          <div className="day">Fri</div>
-          <div className="day">Sat</div>
+          {dayLabels.map(label => (
+            <div key={label} className="day">{label}</div>
+          ))}
         </div>
 
         // (2.2)
@@ -227,7 +224,7 @@ const myFormat = 'yyyy-mm-dd'
 <b>default:</b> 0
 </pre>
 
-Modifies the starting day index of the weeks returned from [`#getWeeksInMonth`](#getweeksinmonth). Defaults to `0 (sunday)`
+Modifies the starting day index of the weeks returned from [`#getWeeksInMonth`](#getweeksinmonth) & [`#getDayLabelsInWeek`](#getdaylabelsinweek). Defaults to `0 (sunday)`
 
 ```jsx
 const monday = 1
@@ -522,6 +519,20 @@ function MyCalendar(kalendaryo) {
 ```
 <br />
 
+#### #getDayLabelsInWeek
+<pre>
+<b>type:</b> func(dayLabelFormat?: String): String[]
+</pre>
+
+Returns an array of strings for each day on a week
+
+  * `getDayLabelsInWeek()` - Returns an array of each day on a week formatted as `'ddd'` and starts on
+  the week index based on the value set on the [`#startWeekAt`](#startweekat) prop
+
+  * `getDayLabelsInWeek(dayLabelFormat)` - Returns an array of each day on a week formatted as the given
+  *dayLabelFormat argument* and starts on the week index based on the value set on the [`#startWeekAt`](#startweekat) prop
+<br />
+
 #### #setDate
 <pre>
 <b>type:</b> func(date: Date): void
@@ -601,6 +612,46 @@ function MyCalendar(kalendaryo) {
 }
 
 <Kalendaryo render={MyCalendar} />
+```
+<br />
+
+#### #setDateNextMonth
+<pre>
+<b>type:</b> func(): void
+</pre>
+
+Updates the [`#date`](#date) state by adding 1 month
+
+```jsx
+function MyCalendar(kalendaryo) {
+  const formattedDate = kalendaryo.getFormattedDate()
+  return (
+    <div>
+      <p>The date today is {formattedDate}</p>
+      <button onClick={kalendaryo.setDateNextMonth}>Click to set date to the next month</button>
+    </div>
+  )
+}
+```
+<br />
+
+#### #setDatePrevMonth
+<pre>
+<b>type:</b> func(): void
+</pre>
+
+Updates the [`#date`](#date) state by subtracting 1 month
+
+```jsx
+function MyCalendar(kalendaryo) {
+  const formattedDate = kalendaryo.getFormattedDate()
+  return (
+    <div>
+      <p>The date today is {formattedDate}</p>
+      <button onClick={kalendaryo.setDatePrevMonth}>Click to set date to the previous month</button>
+    </div>
+  )
+}
 ```
 
 ## Examples

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,22 +28,32 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var dateToDayObjects = function dateToDayObjects(dateValue) {
+/**
+ * @typedef {Object} DayObject - Represents the metadata of a "day"
+ * @property {Date} dateValue - The value of a day's date
+ * @property {number} label - The day's numerical label
+ */
+
+/**
+ * Factory function for creating a {DayObject}
+ * @param {Date} dateValue
+ * @returns {DayObject}
+ */
+function createDayObject(dateValue) {
   return {
     dateValue: dateValue,
     label: (0, _dateFns.getDate)(dateValue)
   };
-};
+}
 
-var getState = function getState(props) {
-  var startCurrentDateAt = props.startCurrentDateAt,
-      startSelectedDateAt = props.startSelectedDateAt;
-
-  return {
-    date: (0, _dateFns.isDate)(startCurrentDateAt) ? startCurrentDateAt : new Date(),
-    selectedDate: (0, _dateFns.isDate)(startSelectedDateAt) ? startSelectedDateAt : new Date()
-  };
-};
+/**
+ * Throws an {Error} with a helpful link for misproperly used methods
+ * @param {string} methodName - The name of the method that is being misproperly used
+ * @throws {Error} Exception for misproperly used methods with a link for their proper use
+ */
+function misusageThrow(methodName) {
+  throw new Error('Invalid usage of #' + methodName + '. ' + 'Please see https://github.com/geeofree/kalendaryo/#' + methodName.toLowerCase() + ' ' + 'to see the proper usage of this method.');
+}
 
 var Kalendaryo = function (_Component) {
   _inherits(Kalendaryo, _Component);
@@ -59,7 +69,23 @@ var Kalendaryo = function (_Component) {
       args[_key] = arguments[_key];
     }
 
-    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Kalendaryo.__proto__ || Object.getPrototypeOf(Kalendaryo)).call.apply(_ref, [this].concat(args))), _this), _this.state = getState(_this.props), _this.getFormattedDate = function () {
+    return _ret = (_temp = (_this = _possibleConstructorReturn(this, (_ref = Kalendaryo.__proto__ || Object.getPrototypeOf(Kalendaryo)).call.apply(_ref, [this].concat(args))), _this), _this.state = {
+      /**
+       * @state {Date} date
+       * @description - State for the current date. Users should only modify this when their calendar
+       * moves to and from a date i.e. changing the month or year of their calendar.
+       * @default [new Date()]
+       */
+      date: (0, _dateFns.isDate)(_this.props.startCurrentDateAt) ? _this.props.startCurrentDateAt : new Date(),
+
+      /**
+       * @state {Date} selectedDate
+       * @description - State for the selected date. Users should only modify this when their calendar
+       * receives a user input such as click events for selecting a day on a calendar
+       * @default [new Date()]
+       */
+      selectedDate: (0, _dateFns.isDate)(_this.props.startSelectedDateAt) ? _this.props.startSelectedDateAt : new Date()
+    }, _this.getFormattedDate = function () {
       var arg = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.state.date;
       var dateFormat = arguments[1];
 
@@ -75,7 +101,7 @@ var Kalendaryo = function (_Component) {
         return (0, _dateFns.format)(arg, dateFormat);
       }
 
-      throw new Error('Invalid arguments passed');
+      misusageThrow('getFormattedDate');
     }, _this.getDateNextMonth = function () {
       var arg = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.state.date;
       var amount = arguments[1];
@@ -92,7 +118,7 @@ var Kalendaryo = function (_Component) {
         return (0, _dateFns.addMonths)(arg, amount);
       }
 
-      throw new Error('Invalid arguments passed');
+      misusageThrow('getDateNextMonth');
     }, _this.getDatePrevMonth = function () {
       var arg = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.state.date;
       var amount = arguments[1];
@@ -109,25 +135,21 @@ var Kalendaryo = function (_Component) {
         return (0, _dateFns.subMonths)(arg, amount);
       }
 
-      throw new Error('Invalid arguments passed');
+      misusageThrow('getDatePrevMonth');
     }, _this.getDaysInMonth = function () {
       var date = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.state.date;
 
       if (!(0, _dateFns.isDate)(date)) throw new Error('Value is not an instance of Date');
-      return (0, _dateFns.eachDay)((0, _dateFns.startOfMonth)(date), (0, _dateFns.endOfMonth)(date)).map(dateToDayObjects);
+      return (0, _dateFns.eachDay)((0, _dateFns.startOfMonth)(date), (0, _dateFns.endOfMonth)(date)).map(createDayObject);
     }, _this.getWeeksInMonth = function () {
       var date = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : _this.state.date;
-      var weekStartsOn = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _this.props.startWeekAt;
+      var startingDayIndex = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : _this.props.startWeekAt;
 
-      if (!(0, _dateFns.isDate)(date)) {
-        throw new Error('First argument must be a date');
+      if (!(0, _dateFns.isDate)(date) || !Number.isInteger(startingDayIndex)) {
+        misusageThrow('getWeeksInMonth');
       }
 
-      if (!Number.isInteger(weekStartsOn)) {
-        throw new Error('Second argument must be an integer');
-      }
-
-      var weekOptions = { weekStartsOn: weekStartsOn };
+      var weekOptions = { weekStartsOn: startingDayIndex };
       var firstDayOfMonth = (0, _dateFns.startOfMonth)(date);
       var firstDayOfFirstWeek = (0, _dateFns.startOfWeek)(firstDayOfMonth, weekOptions);
       var lastDayOfFirstWeek = (0, _dateFns.endOfWeek)(firstDayOfMonth, weekOptions);
@@ -135,7 +157,7 @@ var Kalendaryo = function (_Component) {
       var getWeeks = function getWeeks(startDay, endDay) {
         var weekArray = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : [];
 
-        var week = (0, _dateFns.eachDay)(startDay, endDay).map(dateToDayObjects);
+        var week = (0, _dateFns.eachDay)(startDay, endDay).map(createDayObject);
         var weeks = [].concat(_toConsumableArray(weekArray), [week]);
         var nextWeek = (0, _dateFns.addWeeks)(startDay, 1);
 
@@ -150,6 +172,17 @@ var Kalendaryo = function (_Component) {
       };
 
       return getWeeks(firstDayOfFirstWeek, lastDayOfFirstWeek);
+    }, _this.getDayLabelsInWeek = function () {
+      var dayLabelFormat = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : 'ddd';
+
+      var weekOptions = { weekStartsOn: _this.props.startingDayIndex };
+      var firstDayOfMonth = (0, _dateFns.startOfMonth)(_this.state.date);
+      var firstDayOfFirstWeek = (0, _dateFns.startOfWeek)(firstDayOfMonth, weekOptions);
+      var lastDayOfFirstWeek = (0, _dateFns.endOfWeek)(firstDayOfMonth, weekOptions);
+
+      return (0, _dateFns.eachDay)(firstDayOfFirstWeek, lastDayOfFirstWeek).map(function (d) {
+        return (0, _dateFns.format)(d, dayLabelFormat);
+      });
     }, _this.setDate = function (date) {
       if (!(0, _dateFns.isDate)(date)) throw new Error('Value is not an instance of Date');
       _this.setState({ date: date });
@@ -159,8 +192,143 @@ var Kalendaryo = function (_Component) {
     }, _this.pickDate = function (date) {
       if (!(0, _dateFns.isDate)(date)) throw new Error('Value is not an instance of Date');
       _this.setState({ date: date, selectedDate: date });
+    }, _this.setDateNextMonth = function () {
+      _this.setDate(_this.getDateNextMonth());
+    }, _this.setDatePrevMonth = function () {
+      _this.setDate(_this.getDatePrevMonth());
+    }, _this.getMethods = function () {
+      return {
+        getFormattedDate: _this.getFormattedDate,
+        getDateNextMonth: _this.getDateNextMonth,
+        getDatePrevMonth: _this.getDatePrevMonth,
+        getDaysInMonth: _this.getDaysInMonth,
+        getWeeksInMonth: _this.getWeeksInMonth,
+        getDayLabelsInWeek: _this.getDayLabelsInWeek,
+        setDate: _this.setDate,
+        setSelectedDate: _this.setSelectedDate,
+        pickDate: _this.pickDate,
+        setDateNextMonth: _this.setDateNextMonth,
+        setDatePrevMonth: _this.setDatePrevMonth
+      };
+    }, _this.getUnknownProps = function () {
+      var _this$props = _this.props,
+          startCurrentDateAt = _this$props.startCurrentDateAt,
+          startSelectedDateAt = _this$props.startSelectedDateAt,
+          defaultFormat = _this$props.defaultFormat,
+          onChange = _this$props.onChange,
+          onDateChange = _this$props.onDateChange,
+          onSelectedChange = _this$props.onSelectedChange,
+          render = _this$props.render,
+          unknownProps = _objectWithoutProperties(_this$props, ['startCurrentDateAt', 'startSelectedDateAt', 'defaultFormat', 'onChange', 'onDateChange', 'onSelectedChange', 'render']);
+
+      return unknownProps;
+    }, _this.getRenderArguments = function () {
+      return _extends({}, _this.state, _this.getMethods(), _this.getUnknownProps());
     }, _temp), _possibleConstructorReturn(_this, _ret);
   }
+  /**
+   * @typedef {Object} State - The interal data that can change on this component
+   */
+
+
+  /**
+   * Formats a given {Date} base on the {string} format
+   * @name getFormattedDate
+   * @param {(Date|string)} [arg=this.state.date] - The date to format or a string for formatting
+   * @param {string} [dateFormat] - String for formatting
+   * @returns {string} - Formatted date string
+   * @throws {Error} Exception when argument types are invalid
+   * @see {@link https://date-fns.org/docs/format} for all the possible {String} formats
+   */
+
+
+  /**
+   * Gets the {Date} of the month added by the given {number} amount of months
+   * @name getDateNextMonth
+   * @param {(Date|number)} [arg=this.state.date] - Date to be added or the amount of months to add
+   * @param {number} amount - Amount of months to add on a date
+   * @returns {Date} - A new date with the added months
+   * @throws {Error} Exception when argument types are invalid
+   */
+
+
+  /**
+   * Gets the {Date} of the month subtracted by the given {number} amount of months
+   * @name getDatePrevMonth
+   * @param {(Date|number)} [arg=this.state.date] - Date to be subtracted or the amount of months to subtract
+   * @param {number} amount - Amount of months to subtract on a date
+   * @returns {Date} - A new date with the subtracted months
+   * @throws {Error} Exception when argument types are invalid
+   */
+
+
+  /**
+   * Gets the days in a given month of a {Date}
+   * @name getDaysInMonth
+   * @param {Date} [date=this.state.date] - Date of the desired days in the month
+   * @returns {DayObject[]} - The days in the month of the given date
+   * @throws {Error} Exception when the `date` argument is not a {Date}
+   */
+
+
+  /**
+   * Gets the weeks in a given month of a {Date}
+   * @name getWeeksInMonth
+   * @param {Date} [date=this.state.date] - Date of the desired weeks in the month
+   * @param {number[0..6]} [startingDayIndex=this.props.startWeekAt] - Starting day of the weeks
+   * @returns {Week[DayObject[]]} - The weeks with their respective days of the given month in the date
+   * @throws {Error} Exception when argument types are invalid
+   */
+
+
+  /**
+   * Gets the labels of the days on a week
+   * @name getDayLabelsInWeek
+   * @param {string} [dayLabelFormat='ddd'] - Format of the day labels
+   * @returns {string[]} - An array of each day on a week
+   */
+
+
+  /**
+   * Updates the `date` state to a given {Date}
+   * @name setDate
+   * @param {Date} date - The new date value of the `date` state
+   * @returns {void}
+   * @throws {Error} Exception when the `date` argument is not a {Date}
+   */
+
+
+  /**
+   * Updates the `selectedDate` state to a given {Date}
+   * @name setSelectedDate
+   * @param {Date} selectedDate - The new date value of the `selectedDate` state
+   * @returns {void}
+   * @throws {Error} Exception when the `selectedDate` argument is not a {Date}
+   */
+
+
+  /**
+   * Updates both the `date` and `selectedDate` states to a given {Date}
+   * @name pickDate
+   * @param {Date} date - The new date value of the `date` and `selectedDate` states
+   * @returns {void}
+   * @throws {Error} Exception when the `date` argument is not a {Date}
+   */
+
+
+  /**
+   * Updates the `date` state by 1 month more
+   * @name setDateNextMonth
+   * @returns {void}
+   */
+
+
+  /**
+   * Updates the `date` state by 1 month less
+   * @name setDatePrevMonth
+   * @returns {void}
+   */
+
 
   _createClass(Kalendaryo, [{
     key: 'componentDidUpdate',
@@ -190,54 +358,96 @@ var Kalendaryo = function (_Component) {
   }, {
     key: 'render',
     value: function render() {
-      var state = this.state,
-          props = this.props,
-          getFormattedDate = this.getFormattedDate,
-          getDateNextMonth = this.getDateNextMonth,
-          getDatePrevMonth = this.getDatePrevMonth,
-          getDaysInMonth = this.getDaysInMonth,
-          getWeeksInMonth = this.getWeeksInMonth,
-          setDate = this.setDate,
-          setSelectedDate = this.setSelectedDate,
-          pickDate = this.pickDate;
-
-      var startCurrentDateAt = props.startCurrentDateAt,
-          defaultFormat = props.defaultFormat,
-          onChange = props.onChange,
-          onDateChange = props.onDateChange,
-          onSelectedChange = props.onSelectedChange,
-          render = props.render,
-          rest = _objectWithoutProperties(props, ['startCurrentDateAt', 'defaultFormat', 'onChange', 'onDateChange', 'onSelectedChange', 'render']);
-
-      return render(_extends({}, rest, state, {
-        getFormattedDate: getFormattedDate,
-        getDateNextMonth: getDateNextMonth,
-        getDatePrevMonth: getDatePrevMonth,
-        getDaysInMonth: getDaysInMonth,
-        getWeeksInMonth: getWeeksInMonth,
-        setDate: setDate,
-        setSelectedDate: setSelectedDate,
-        pickDate: pickDate
-      }));
+      return this.props.render(this.getRenderArguments());
     }
   }]);
 
   return Kalendaryo;
 }(_react.Component);
 
+Kalendaryo.propTypes = {
+  /**
+   * @prop {string} defaultFormat
+   * @description - Modifies the `getFormattedDate` method's date string format
+   * @default ['MM/DD/YY']
+   * @see {@link https://date-fns.org/docs/format} for all the possible string formats
+   */
+  defaultFormat: _propTypes2.default.string,
+
+  /**
+   * @prop {(Date|any)} startCurrentDateAt
+   * @description - Modifies the initial state value of `date`
+   * @note - If the given value is not a {Date}, the `date` state will default to today's date
+   */
+  startCurrentDateAt: _propTypes2.default.any,
+
+  /**
+   * @prop {(Date|any)} startSelectedDateAt
+   * @description - Modifies the initial state value of `selectedDate`
+   * @note - If the given value is not a {Date}, the `selectedDate` state will default to today's date
+   */
+  startSelectedDateAt: _propTypes2.default.any,
+
+  /**
+   * @prop {number[0..6]} startWeekAt
+   * @description - Modifies the starting day of the weeks  on the `getWeeksInMonth` & `getDayLabelsInWeek` methods
+   * @note - The values must be in the range of Sunday(0) to Saturday(6)
+   * @default [0]
+   */
+  startWeekAt: _propTypes2.default.number,
+
+  /**
+   * @callback onChangeCallback
+   * @prop {func} onChange
+   * @param {State} state
+   * @description - Callback Prop for listening to changes on the component's `state`
+   * @returns {void}
+   */
+  onChange: _propTypes2.default.func,
+
+  /**
+   * @callback onDateChangeCallback
+   * @prop {func} onDateChange
+   * @param {Date} date
+   * @description - Callback Prop for listening to changes only to the component's `date` state
+   * @returns {void}
+   */
+  onDateChange: _propTypes2.default.func,
+
+  /**
+   * @callback onSelectedChangeCallback
+   * @prop {func} onSelectedChange
+   * @param {Date} selectedDate
+   * @description - Callback Prop for listening to changes only to the component's `selectedDate` state
+   * @returns {void}
+   */
+  onSelectedChange: _propTypes2.default.func,
+
+  /**
+   * @required
+   * @callback renderPropCallback
+   * @prop {func} render
+   * @param {Date} date
+   * @param {Date} selectedDate
+   * @param {func} getFormattedDate
+   * @param {func} getDateNextMonth
+   * @param {func} getDatePrevMonth
+   * @param {func} getDaysInMonth
+   * @param {func} getWeeksInMonth
+   * @param {func} setDate
+   * @param {func} setSelectedDate
+   * @param {func} pickDate
+   * @param {any} [...unknownProps]
+   * @description - Callback prop responsible for rendering the calendar's layout and functionality.
+   * Receives both the `date` and `selectedDate` states, all of the component's methods, as well
+   * as any unknown props given to the component
+   * @returns {?ReactElement}
+   */
+  render: _propTypes2.default.func.isRequired
+};
 Kalendaryo.defaultProps = {
   startWeekAt: 0,
+  defaultFormat: 'MM/DD/YY',
   startCurrentDateAt: new Date(),
-  startSelectedDateAt: new Date(),
-  defaultFormat: 'MM/DD/YY'
-};
-Kalendaryo.propTypes = {
-  render: _propTypes2.default.func.isRequired,
-  onChange: _propTypes2.default.func,
-  onDateChange: _propTypes2.default.func,
-  onSelectedChange: _propTypes2.default.func,
-  startWeekAt: _propTypes2.default.number,
-  defaultFormat: _propTypes2.default.string,
-  startCurrentDateAt: _propTypes2.default.any
-};
+  startSelectedDateAt: new Date() };
 exports.default = Kalendaryo;

--- a/src/index.js
+++ b/src/index.js
@@ -279,6 +279,21 @@ class Kalendaryo extends Component {
   }
 
   /**
+   * Gets the labels of the days on a week
+   * @name getDayLabelsInWeek
+   * @param {string} [dayLabelFormat='ddd'] - Format of the day labels
+   * @returns {string[]} - An array of each day on a week
+   */
+  getDayLabelsInWeek = (dayLabelFormat = 'ddd') => {
+    const weekOptions = { weekStartsOn: this.props.startingDayIndex }
+    const firstDayOfMonth = startOfMonth(this.state.date)
+    const firstDayOfFirstWeek = startOfWeek(firstDayOfMonth, weekOptions)
+    const lastDayOfFirstWeek = endOfWeek(firstDayOfMonth, weekOptions)
+
+    return eachDay(firstDayOfFirstWeek, lastDayOfFirstWeek).map(d => format(d, dayLabelFormat))
+  }
+
+  /**
    * Updates the `date` state to a given {Date}
    * @name setDate
    * @param {Date} date - The new date value of the `date` state
@@ -314,6 +329,24 @@ class Kalendaryo extends Component {
     this.setState({ date, selectedDate: date })
   }
 
+  /**
+   * Updates the `date` state by 1 month more
+   * @name setDateNextMonth
+   * @returns {void}
+   */
+  setDateNextMonth = () => {
+    this.setDate(this.getDateNextMonth())
+  }
+
+  /**
+   * Updates the `date` state by 1 month less
+   * @name setDatePrevMonth
+   * @returns {void}
+   */
+  setDatePrevMonth = () => {
+    this.setDate(this.getDatePrevMonth())
+  }
+
   componentDidUpdate (_, prevState) {
     const { onChange, onDateChange, onSelectedChange } = this.props
 
@@ -340,9 +373,12 @@ class Kalendaryo extends Component {
     getDatePrevMonth: this.getDatePrevMonth,
     getDaysInMonth: this.getDaysInMonth,
     getWeeksInMonth: this.getWeeksInMonth,
+    getDayLabelsInWeek: this.getDayLabelsInWeek,
     setDate: this.setDate,
     setSelectedDate: this.setSelectedDate,
-    pickDate: this.pickDate
+    pickDate: this.pickDate,
+    setDateNextMonth: this.setDateNextMonth,
+    setDatePrevMonth: this.setDatePrevMonth
   })
 
   getUnknownProps = () => {

--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,7 @@ class Kalendaryo extends Component {
 
     /**
      * @prop {number[0..6]} startWeekAt
-     * @description - Modifies the starting day week of the month for the `getWeeksInMonth` method
+     * @description - Modifies the starting day of the weeks  on the `getWeeksInMonth` & `getDayLabelsInWeek` methods
      * @note - The values must be in the range of Sunday(0) to Saturday(6)
      * @default [0]
      */

--- a/tests/kalendaryo.spec.js
+++ b/tests/kalendaryo.spec.js
@@ -391,6 +391,23 @@ describe('<Kalendaryo />', () => {
       })
     })
 
+    describe('#getDayLabelsInWeek', () => {
+      test('it returns the correct day labels on a week', () => {
+        const getInstance = (startWeekAt) => getComponentInstance({ startWeekAt })
+        let component = kalendaryo
+        let dayLabels = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+
+        let startingDayIndex = 0
+        while (startingDayIndex < 7) {
+          component.getDayLabelsInWeek().forEach((l, i) => {
+            expect(l).toBe(dayLabels[i])
+          })
+          startingDayIndex += 1
+          component = getInstance(startingDayIndex)
+        }
+      })
+    })
+
     describe('#setDate', () => {
       test('it throws an error on invalid date values given the argument: (notADateObject)', () => {
         expect(() => kalendaryo.setDate(false)).toThrow()
@@ -446,6 +463,22 @@ describe('<Kalendaryo />', () => {
 
         expect(dateAfter).not.toBe(dateNow)
         expect(selectedDateAfter).not.toBe(selectedDateNow)
+      })
+    })
+
+    describe('#setDateNextMonth', () => {
+      test('it correctly updates the `date` state by 1 month more', () => {
+        const getDateNextMonth = () => addMonths(dateToday, 1)
+        kalendaryo.setDateNextMonth()
+        expect(kalendaryo.getFormattedDate()).toBe(kalendaryo.getFormattedDate(getDateNextMonth()))
+      })
+    })
+
+    describe('#setDatePrevMonth', () => {
+      test('it correctly updates the `date` state by 1 month less', () => {
+        const getDatePrevMonth = () => subMonths(dateToday, 1)
+        kalendaryo.setDatePrevMonth()
+        expect(kalendaryo.getFormattedDate()).toBe(kalendaryo.getFormattedDate(getDatePrevMonth()))
       })
     })
   })


### PR DESCRIPTION
## Changelog
- [x] Add `setDateNextMonth` shortcut method as an alias to `setDate(getDateNextMonth())`
- [x] Add `setDatePrevtMonth` shortcut method as an alias to `setDate(getDatePrevMonth())`
- [x] Add `getDayLabelsInWeek` method for getting an array of labels of days on a week